### PR TITLE
[FIX] result API fix

### DIFF
--- a/src/main/java/com/smileflower/santa/profile/repository/ProfileJdbcRepository.java
+++ b/src/main/java/com/smileflower/santa/profile/repository/ProfileJdbcRepository.java
@@ -141,7 +141,7 @@ public class ProfileJdbcRepository implements ProfileRepository {
 
     @Override
     public int findHighSumByIdx(int userIdx) {
-        return this.jdbcTemplate.queryForObject("SELECT SUM(c.high) FROM (SELECT b.high FROM flag a INNER JOIN mountain b ON a.mountainIdx = b.mountainIdx WHERE a.userIdx = ?) c",new Object[]{userIdx}, Integer.class);
+        return this.jdbcTemplate.queryForObject("SELECT COALESCE(SUM(b.high),0) as sum FROM flag a INNER JOIN mountain b ON a.mountainIdx = b.mountainIdx WHERE a.userIdx = ?",new Object[]{userIdx}, Integer.class);
     }
 
 

--- a/src/main/java/com/smileflower/santa/profile/service/ProfileService.java
+++ b/src/main/java/com/smileflower/santa/profile/service/ProfileService.java
@@ -194,7 +194,6 @@ public class ProfileService {
         int flagCount = profileRepository.findFlagCountByIdx(userIdx);
         int diffFlagCount = profileRepository.findDiffFlagCountByIdx(userIdx);
         int highCount = profileRepository.findHighSumByIdx(userIdx);
-
         return new ResultResponse(flagCount>0,flagCount>2,flagCount>6,flagCount>9,
                 highCount>49999, highCount>99999,highCount>199999,diffFlagCount>99,
                 diffFlagCount>2,diffFlagCount>6,diffFlagCount>9,(double)highCount/1000);


### PR DESCRIPTION
result API에서 highSum query에서 사용자가 오른 산이 없을 경우 SUM 집계함수가 NULL을 반환해 COALESCE(SUM(b.high),0) 와 같이 COALESCE 키워드를 사용하여 수정