### PR TITLE
[FIX] flag POST API -> json 말고 text로 받는 api 추가 개발

### DIFF
--- a/src/main/java/com/smileflower/santa/flag/controller/FlagsController.java
+++ b/src/main/java/com/smileflower/santa/flag/controller/FlagsController.java
@@ -35,4 +35,17 @@ public class FlagsController {
                 flagsService.uploadImage(gpsInfoRequest, file, userIdx, mountainIdx)
         );
     }
+
+    @PostMapping(path = "/{mountainIdx}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResult<UploadImageResponse> uploadFlag(@RequestParam("latitude") double latitude, @RequestParam("longitude") double longitude,
+                                                     @RequestParam("altitude") double altitude, @RequestPart(required = false) MultipartFile file,
+                                                     @PathVariable("mountainIdx") Long mountainIdx) {
+        int userIdx = -1;
+        if (jwtService.validateToken()) {
+            userIdx = jwtService.getUserIdxV2();
+        }
+        return ApiResult.OK(
+                flagsService.uploadImage(new GpsInfoRequest(latitude,longitude,altitude), file, userIdx, mountainIdx)
+        );
+    }
 }


### PR DESCRIPTION
### Flag API 
* [FIX] flag POST API -> json 말고 text로 받는 api 추가 개발
* 사유 : ios client에서 json으로 request 으로 직렬화하는 과정이 어려워 text 버전 api 개발 요청 받음.